### PR TITLE
add builtin set function

### DIFF
--- a/src/eval/builtins.ts
+++ b/src/eval/builtins.ts
@@ -20,6 +20,7 @@ export const builtins: Record<string, BuiltInObject> = {
 	last: getBuiltinByName("last")!,
 	rest: getBuiltinByName("rest")!,
 	push: getBuiltinByName("push")!,
+	set: getBuiltinByName("set")!,
 	map: new BuiltInObject(({ args }) => {
 		if (args.length !== 2) {
 			return new ErrorObject(

--- a/src/object/builtins.ts
+++ b/src/object/builtins.ts
@@ -4,13 +4,16 @@ import type { Maybe } from "../utils/types";
 import { VM } from "../vm/vm";
 import {
 	ArrayObject,
+	BooleanObject,
 	BuiltInObject,
 	type ClosureObject,
 	ErrorObject,
+	HashObject,
 	IntegerObject,
 	type InternalObject,
 	NULL_OBJ,
 	ObjectType,
+	StringObject,
 	TRUE_OBJ,
 } from "./object";
 
@@ -277,6 +280,30 @@ export const builtins: { name: string; builtin: BuiltInObject }[] = [
 				}
 			}
 			return new ArrayObject(filtered);
+		}),
+	},
+	{
+		name: "set",
+		builtin: new BuiltInObject(({ args }) => {
+			const hashmap = args[0] as HashObject;
+			const key = args[1] as Maybe<InternalObject>;
+			const value = args[2] as Maybe<InternalObject>;
+			if (!(hashmap instanceof HashObject)) {
+				return new ErrorObject(
+					`set's first argument must be a hashmap, got ${args[0]?.type()}`,
+				);
+			}
+			if (
+				!(
+					key instanceof IntegerObject ||
+					key instanceof BooleanObject ||
+					key instanceof StringObject
+				)
+			) {
+				return new ErrorObject("not a valid hash key");
+			}
+			hashmap.pairs.set(key.value, { key, value });
+			return NULL_OBJ;
 		}),
 	},
 ];

--- a/src/vm/vm.test.ts
+++ b/src/vm/vm.test.ts
@@ -532,6 +532,30 @@ describe("vm", () => {
 					"let global = 5;map([1,2,3,4],fn (x){let multiplier =2; (x+global)*multiplier})",
 				expected: [12, 14, 16, 18],
 			},
+			{
+				input: `let map ={"a":1}; set(map,"b",2); map["b"]`,
+				expected: 2,
+			},
+			{
+				input: `let map ={"a":1}; set(map,"b",2); map["b"]`,
+				expected: 2,
+			},
+			{
+				input: ` set([],"b",2)`,
+				expected: new ErrorObject(
+					"set's first argument must be a hashmap, got ARRAY",
+				),
+			},
+			{
+				input: "set(1,1,1)",
+				expected: new ErrorObject(
+					"set's first argument must be a hashmap, got INTEGER",
+				),
+			},
+			{
+				input: "set({},[],1)",
+				expected: new ErrorObject("not a valid hash key"),
+			},
 		]);
 	});
 	it("should execute closures", () => {


### PR DESCRIPTION
Allows modification of hashmap.
 Examples below:

```js
let map = { a: 1 };
set(map, "b", 2);
map["b"] //2

```
```
let fib = fn (n, cache) {
  if (n < 2) {
    return n;
  }
  if (!cache[n]) {
    set(cache, n, fib(n - 1, cache) + fib(n - 2, cache));
  }
  return cache[n];
};
fib(55, {});

```